### PR TITLE
Create_function deprecated in PHP 7.2, use anonymous function instead

### DIFF
--- a/includes/widgets/embm-widget-list.php
+++ b/includes/widgets/embm-widget-list.php
@@ -176,7 +176,7 @@ class EMBM_Widget_List extends WP_Widget
 }
 
 // Load the widget
-add_action('widgets_init', create_function('', 'return register_widget("EMBM_Widget_List");'));
+add_action('widgets_init', function() { return register_widget("EMBM_Widget_List"); });
 
 /**
  * Generate HTML content of Beer List widget


### PR DESCRIPTION
`create_function` will be removed from future PHP versions because it's unsafe. The advice is to use anonymous function calls instead.