### PR TITLE
Fixes error thrown in later versions of PHP.

### DIFF
--- a/includes/embm-core.php
+++ b/includes/embm-core.php
@@ -320,7 +320,7 @@ function EMBM_Core_Beer_untappd($post_id)
     $res = EMBM_Admin_Untappd_beer($api_root, $beer_id, $post_id);
 
     // Return data
-    if (!is_null($res) && array_key_exists('beer', $res)) {
+    if (!is_null($res) && is_array($res) && array_key_exists('beer', $res)) {
         return $res['beer'];
     } else if (is_string($res)) {
         return $res;


### PR DESCRIPTION
* In later versions of PHP, `array_key_exists` will throw an error if the second parameter is not an array.
* This fix adds `is_array` before proceeding to `array_key_exists`.
* Tested with WordPress 5.7.2 and PHP 7.4